### PR TITLE
Support for node based resolution in build

### DIFF
--- a/build.js
+++ b/build.js
@@ -8,9 +8,10 @@ const ngc = require('@angular/compiler-cli/src/main').main;
 const rollup = require('rollup');
 const uglify = require('rollup-plugin-uglify');
 const sourcemaps = require('rollup-plugin-sourcemaps');
+const nodeResolve = require('rollup-plugin-node-resolve');
+const commonjs = require('rollup-plugin-commonjs');
 
 const inlineResources = require('./inline-resources');
-
 
 const libName = require('./package.json').name;
 const rootFolder = path.join(__dirname);
@@ -66,7 +67,11 @@ return Promise.resolve()
         '@angular/core'
       ],
       plugins: [
-        sourcemaps()
+        commonjs({
+          include: ['node_modules/rxjs/**']
+        }),
+        sourcemaps(),
+        nodeResolve({ jsnext: true, module: true })
       ]
     };
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "rollup": "^0.42.0",
     "rollup-plugin-sourcemaps": "^0.4.1",
     "rollup-plugin-uglify": "^2.0.1",
+    "rollup-plugin-commonjs": "^8.0.2",
+    "rollup-plugin-node-resolve": "^3.0.0",
     "rxjs": "^5.0.1",
     "standard-version": "^4.0.0",
     "systemjs": "^0.19.40",


### PR DESCRIPTION
Added support for node based resolution in the `build.js`. This is required when your `src/lib` has inner folders and you use `index.ts` or `package.json` or any other mechanism to export classes to parent directory.

Also fixed the build failures from RxJS not exporting certain modules as described here - https://angular.io/guide/aot-compiler#rollup-plugins