### PR TITLE
feature: keep tsc output out of src and demo directories

### DIFF
--- a/bs-config.js
+++ b/bs-config.js
@@ -1,0 +1,15 @@
+
+module.exports = {
+  "server": {
+    "baseDir": ["src/demo", "out-tsc/demo"],
+    "routes": {
+      "/node_modules": "node_modules",
+      "/quickstart-lib": "src/lib",
+      "/quickstart-lib-js": "out-tsc/lib"
+    },
+    middleware: [function (req, res, next) {
+      req.url = req.url.replace(/^\/quickstart-lib\/(.*\.(js|map))/, '/quickstart-lib-js/$1');
+      return next();
+    }]
+  }
+};

--- a/bs-config.json
+++ b/bs-config.json
@@ -1,9 +1,0 @@
-{
-  "server": {
-    "baseDir": "src/demo",
-    "routes": {
-      "/node_modules": "node_modules",
-      "/quickstart-lib": "src/lib"
-    }
-  }
-}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "node build.js",
     "build-demo": "tsc -p src/demo/",
     "build-demo:watch": "tsc -p src/demo/ -w",
-    "serve": "lite-server -c=bs-config.json",
+    "serve": "lite-server -c=bs-config.js",
     "prestart": "npm run build-demo",
     "start": "concurrently \"npm run build-demo:watch\" \"npm run serve\"",
     "build-test": "tsc -p src/lib/tsconfig.spec.json",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "outDir": "out-tsc",
     "target": "es5",
     "module": "es2015",
     "moduleResolution": "node",


### PR DESCRIPTION
To keep the src folders clean, the typescript compiler output is place in the `out-tsc` folder. Liteserver configuration is modified so  that requests  for `.js` or `.map` files are redirected to the `out-tsc` directory.